### PR TITLE
Support count-style verbose flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The intent of `unfig` is to consolidate all of that capability, so that we
 just need to specify what configuration exists (and optionally how it can be
 supplied) in a straightforward way, and stop worrying about it.
 
-## Usage Example (currently tentative)
+## Usage Example
 
 Let's invoke Unfig like this, as an example:
 
@@ -63,6 +63,10 @@ And for each parameter, we have these options:
   cli - it is required, must be a non-blank string, and may contain no newlines.
 * `type` - this is the type to cast the supplied values into - it is required,
   and must be one of "boolean", "string", "integer", or "float" (a String).
+* `count` - this is only relevant to _integer_ flags - if supplied on one, it
+  behaves the same for other methods, but the ArgvParser will count how often
+  the flag is supplied, rather than taking value. This is generally only used
+  for `-vvv` style verbose flagging.
 * `multi` - this specifies whether the parameter can be "multi-valued" (default
   is false). If true, supplying the flag more than once, or supplying an array
   of values in the config file, or (more awkwardly) setting multiple environment

--- a/lib/unfig/argv_loader.rb
+++ b/lib/unfig/argv_loader.rb
@@ -73,19 +73,30 @@ module Unfig
       args << p.description
     end
 
+    def initialize_flag_for(p)
+      if p.count?
+        @options[p.name] ||= 0
+      elsif p.multi?
+        @options[p.name] ||= []
+      end
+    end
+
+    def handle_flag_for(p, name, value)
+      if p.count?
+        @options[name] += 1
+      elsif p.multi?
+        @options[name] << value
+      elsif @options.key?(name)
+        raise FlagError, "Cannot supply #{name} more than once"
+      else
+        @options[name] = value
+      end
+    end
+
     def add_option_for(opts, p)
       opts.on(*option_args(p)) do |value|
-        if p.count?
-          @options[p.name] ||= 0
-          @options[p.name] += 1
-        elsif p.multi?
-          @options[p.name] ||= []
-          @options[p.name] << value
-        elsif @options.key?(p.name)
-          raise FlagError, "Cannot supply #{p.name} more than once"
-        else
-          @options[p.name] = value
-        end
+        initialize_flag_for(p)
+        handle_flag_for(p, p.name, value)
       end
     end
 

--- a/lib/unfig/argv_loader.rb
+++ b/lib/unfig/argv_loader.rb
@@ -37,7 +37,7 @@ module Unfig
     end
 
     def short_arg(p)
-      if p.type == "boolean"
+      if p.type == "boolean" || p.count?
         "-#{p.short}"
       else
         "-#{p.short}#{p.name.upcase}"
@@ -45,7 +45,9 @@ module Unfig
     end
 
     def long_arg(p)
-      if p.type == "boolean"
+      if p.count?
+        "--#{p.long}"
+      elsif p.type == "boolean"
         "--[no-]#{p.long}"
       else
         "--#{p.long}=#{p.name.upcase}"
@@ -73,7 +75,10 @@ module Unfig
 
     def add_option_for(opts, p)
       opts.on(*option_args(p)) do |value|
-        if p.multi?
+        if p.count?
+          @options[p.name] ||= 0
+          @options[p.name] += 1
+        elsif p.multi?
           @options[p.name] ||= []
           @options[p.name] << value
         elsif @options.key?(p.name)

--- a/lib/unfig/param_config.rb
+++ b/lib/unfig/param_config.rb
@@ -31,6 +31,8 @@ module Unfig
 
     def multi? = data.fetch(:multi, false)
 
+    def count? = type == "integer" && data.fetch(:count, false)
+
     def enabled
       if data.key?(:enabled)
         data.fetch(:enabled)

--- a/spec/unfig/argv_loader_spec.rb
+++ b/spec/unfig/argv_loader_spec.rb
@@ -3,10 +3,10 @@ RSpec.describe Unfig::ArgvLoader do
 
   let(:params) { instance_double(Unfig::ParamsConfig, banner: "My Banner", params: [foo, bar, baz, bam]) }
   let(:all) { ["short", "long", "env", "file"] }
-  let(:foo) { instance_double(Unfig::ParamConfig, name: "foo", enabled: all, multi?: false, type: "string", short: "f", long: "foo", description: "My Foo") }
-  let(:bar) { instance_double(Unfig::ParamConfig, name: "bar", enabled: all, multi?: false, type: "boolean", short: "b", long: "bar", description: "My Bar") }
-  let(:baz) { instance_double(Unfig::ParamConfig, name: "baz", enabled: all, multi?: true, type: "integer", short: "z", long: "baz", description: "My Baz") }
-  let(:bam) { instance_double(Unfig::ParamConfig, name: "bam", enabled: all, multi?: false, type: "float", short: "m", long: "bam", description: "My Bam") }
+  let(:foo) { instance_double(Unfig::ParamConfig, name: "foo", enabled: all, count?: false, multi?: false, type: "string", short: "f", long: "foo", description: "My Foo") }
+  let(:bar) { instance_double(Unfig::ParamConfig, name: "bar", enabled: all, count?: false, multi?: false, type: "boolean", short: "b", long: "bar", description: "My Bar") }
+  let(:baz) { instance_double(Unfig::ParamConfig, name: "baz", enabled: all, count?: false, multi?: true, type: "integer", short: "z", long: "baz", description: "My Baz") }
+  let(:bam) { instance_double(Unfig::ParamConfig, name: "bam", enabled: all, count?: false, multi?: false, type: "float", short: "m", long: "bam", description: "My Bam") }
 
   let(:argv) { [] }
 
@@ -112,6 +112,25 @@ RSpec.describe Unfig::ArgvLoader do
           expect { read }.to raise_error(OptionParser::MissingArgument, /--baz/)
         end
       end
+
+      context "with count: true" do
+        let(:baz) { instance_double(Unfig::ParamConfig, name: "baz", enabled: all, count?: true, type: "integer", short: "z", long: "baz", description: "My Baz") }
+
+        context "and it is not supplied" do
+          let(:argv) { [] }
+          it { is_expected.not_to include("baz") }
+        end
+
+        context "and it is supplied once" do
+          let(:argv) { ["--baz"] }
+          it { is_expected.to include("baz" => 1) }
+        end
+
+        context "and it is supplied several times" do
+          let(:argv) { ["-zz", "--baz", "-z"] }
+          it { is_expected.to include("baz" => 4) }
+        end
+      end
     end
 
     context "when a float is supplied" do
@@ -140,7 +159,7 @@ RSpec.describe Unfig::ArgvLoader do
     end
 
     context "when attempting to convert an unrecognized type" do
-      let(:foo) { instance_double(Unfig::ParamConfig, name: "foo", enabled: all, multi?: false, type: "hash", short: "f", long: "foo", description: "My Foo") }
+      let(:foo) { instance_double(Unfig::ParamConfig, name: "foo", enabled: all, count?: false, multi?: false, type: "hash", short: "f", long: "foo", description: "My Foo") }
       let(:argv) { ["--foo=hi"] }
 
       it "raises Invalid" do

--- a/spec/unfig/param_config_spec.rb
+++ b/spec/unfig/param_config_spec.rb
@@ -2,13 +2,14 @@ RSpec.describe Unfig::ParamConfig do
   subject(:pc) { described_class.new(supplied_name, data) }
 
   let(:supplied_name) { "foo" }
-  let(:base_data) { {description:, type:, enabled:, default:, multi:, env:, long:, short:} }
+  let(:base_data) { {description:, type:, enabled:, default:, multi:, count:, env:, long:, short:} }
   let(:data) { base_data }
   let(:description) { "Foo is for foo" }
   let(:type) { "boolean" }
   let(:enabled) { ["long", "short", "file"] }
   let(:default) { true }
   let(:multi) { false }
+  let(:count) { false }
   let(:env) { "FOO_ENV" }
   let(:long) { "foo-foo" }
   let(:short) { "o" }
@@ -84,6 +85,53 @@ RSpec.describe Unfig::ParamConfig do
     context "when supplied as a string" do
       let(:env) { "FOO2" }
       it { is_expected.to eq("FOO2") }
+    end
+  end
+
+  describe "#multi?" do
+    subject { pc.multi? }
+
+    context "when not supplied" do
+      let(:data) { base_data.except(:multi) }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when supplied as true" do
+      let(:default) { [] }
+      let(:multi) { true }
+      it { is_expected.to eq(true) }
+    end
+
+    context "when supplied as false" do
+      let(:multi) { false }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "#count?" do
+    subject { pc.count? }
+
+    let(:type) { "integer" }
+    let(:default) { nil }
+
+    context "when not supplied" do
+      let(:data) { base_data.except(:count) }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when supplied as true" do
+      let(:count) { true }
+      it { is_expected.to eq(true) }
+
+      context "on a non-integer param" do
+        let(:type) { "string" }
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "when supplied as false" do
+      let(:count) { false }
+      it { is_expected.to eq(false) }
     end
   end
 end


### PR DESCRIPTION
One type of commonly-used flag that wasn't supported was the old-style _verbose_ flags that have multiple levels - supplying `-vvv` to mean "verbosity level 3" was.. _possible_, but you had to use a 'multi-boolean' and then count the "true"s.

This fixes #1, adding an optional `count: true` (only for 'integer' type flags) which tells the ArgvParser to make a boolean flag, and then count how often it is supplied.