### PR TITLE
Support `env_prefix` for default env-names

### DIFF
--- a/lib/unfig/loader.rb
+++ b/lib/unfig/loader.rb
@@ -7,6 +7,7 @@ module Unfig
       @values = values
       @format = options.fetch(:format, :hash)
       @banner = options.fetch(:banner, nil)
+      @env_prefix = options.fetch(:env_prefix, "")
     end
 
     def read
@@ -22,13 +23,13 @@ module Unfig
 
     private
 
-    attr_reader :config, :values, :format, :banner
+    attr_reader :config, :values, :format, :banner, :env_prefix
 
     def argv = (@argv == UNSUPPLIED) ? ARGV : @argv
 
     def env = (@env == UNSUPPLIED) ? ENV.to_h : @env
 
-    def params = @_params ||= ParamsConfig.new(banner:, params: values)
+    def params = @_params ||= ParamsConfig.new(banner:, env_prefix:, params: values)
 
     def loaded_argv
       return @_loaded_argv if defined?(@_loaded_argv)

--- a/lib/unfig/param_config.rb
+++ b/lib/unfig/param_config.rb
@@ -13,9 +13,10 @@ module Unfig
   class ParamConfig
     KNOWN_ENABLED_VALUES = ["long", "short", "env", "file"].to_set.freeze
 
-    def initialize(name, data)
+    def initialize(name, data, env_prefix:)
       @name = name
       @data = data.transform_keys(&:to_sym)
+      @env_prefix = env_prefix
       ParamValidator.new(@name, @data).validate!
     end
 
@@ -55,14 +56,14 @@ module Unfig
 
     def env
       if data.key?(:env)
-        data.fetch(:env, nil)
+        env_prefix + data.fetch(:env, nil)
       else
-        name.upcase
+        env_prefix + name.upcase
       end
     end
 
     private
 
-    attr_reader :data
+    attr_reader :data, :env_prefix
   end
 end

--- a/lib/unfig/param_config.rb
+++ b/lib/unfig/param_config.rb
@@ -56,7 +56,7 @@ module Unfig
 
     def env
       if data.key?(:env)
-        env_prefix + data.fetch(:env, nil)
+        data.fetch(:env, nil)
       else
         env_prefix + name.upcase
       end

--- a/lib/unfig/param_config.rb
+++ b/lib/unfig/param_config.rb
@@ -13,8 +13,6 @@ module Unfig
   class ParamConfig
     KNOWN_ENABLED_VALUES = ["long", "short", "env", "file"].to_set.freeze
 
-    def self.load(params_data) = params_data.map { |key, value| new(key, value) }
-
     def initialize(name, data)
       @name = name
       @data = data.transform_keys(&:to_sym)

--- a/lib/unfig/params_config.rb
+++ b/lib/unfig/params_config.rb
@@ -7,15 +7,14 @@ module Unfig
       raise(Invalid, "Params-config must be a Hash") unless data.is_a?(Hash)
       raise(Invalid, "Params-config must supply some params (as a Hash)") unless data[:params].is_a?(Hash)
       @data = data
+      validate!
     end
 
-    def params
-      return @_params if defined?(@_params)
-      validate!
-      @_params = built
-    end
+    def params = @_params ||= data[:params].map { |k, v| ParamConfig.new(k, v) }
 
     def banner = data[:banner]
+
+    def env_prefix = data[:env_prefix] || ""
 
     private
 
@@ -24,6 +23,8 @@ module Unfig
     def built = @_built ||= data[:params].map { |k, v| ParamConfig.new(k, v) }
 
     def validate!
+      validate_banner_is_string!
+      validate_env_prefix_is_solid_string!
       validate_no_duplicate_names!
       validate_no_duplicate_long_flags!
       validate_no_duplicate_short_flags!
@@ -58,6 +59,20 @@ module Unfig
       return if dups.none?
 
       raise Invalid, "Duplicate env-names: #{dups.join(", ")}"
+    end
+
+    def validate_banner_is_string!
+      return if banner.nil? || banner.is_a?(String)
+
+      raise Invalid, "Non-string banner supplied"
+    end
+
+    def validate_env_prefix_is_solid_string!
+      if !env_prefix.is_a?(String)
+        raise Invalid, "Non-string env_prefix supplied"
+      elsif /\s/.match?(env_prefix)
+        raise Invalid, "No whitespace is allowed in env_prefix"
+      end
     end
   end
 end

--- a/lib/unfig/params_config.rb
+++ b/lib/unfig/params_config.rb
@@ -10,7 +10,7 @@ module Unfig
       validate!
     end
 
-    def params = @_params ||= data[:params].map { |k, v| ParamConfig.new(k, v) }
+    def params = @_params ||= data[:params].map { |k, v| ParamConfig.new(k, v, env_prefix:) }
 
     def banner = data[:banner]
 
@@ -20,7 +20,7 @@ module Unfig
 
     attr_reader :data
 
-    def built = @_built ||= data[:params].map { |k, v| ParamConfig.new(k, v) }
+    def built = @_built ||= data[:params].map { |k, v| ParamConfig.new(k, v, env_prefix:) }
 
     def validate!
       validate_banner_is_string!

--- a/spec/fixtures/test_script
+++ b/spec/fixtures/test_script
@@ -8,6 +8,7 @@ opts = Unfig.load_options(
   format: :struct,
   config: config_path,
   banner: "Usage: like, whatever really",
+  env_prefix: "TEST_",
   values: {
     verbose: {description: "print lots?", type: "boolean", default: false, enabled: %w[short long env]},
     color: {description: "in color?", type: "boolean", default: true},

--- a/spec/unfig/loader_spec.rb
+++ b/spec/unfig/loader_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe Unfig::Loader do
-  subject(:loader) { described_class.new(values:, format:, banner:, **inputs) }
+  subject(:loader) { described_class.new(values:, format:, banner:, env_prefix:, **inputs) }
 
   let(:inputs) { {} }
   let(:format) { :hash }
   let(:banner) { nil }
+  let(:env_prefix) { "" }
 
   let(:values) do
     {
@@ -22,6 +23,12 @@ RSpec.describe Unfig::Loader do
 
   describe "#read" do
     subject(:read) { loader.read }
+
+    it "constructs the expected ParamsConfig" do
+      allow(Unfig::ParamsConfig).to receive(:new).and_call_original
+      read
+      expect(Unfig::ParamsConfig).to have_received(:new).with(banner:, env_prefix:, params: values)
+    end
 
     context "when format is :hash" do
       let(:format) { :hash }

--- a/spec/unfig/param_config_spec.rb
+++ b/spec/unfig/param_config_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Unfig::ParamConfig do
-  subject(:pc) { described_class.new(supplied_name, data) }
+  subject(:pc) { described_class.new(supplied_name, data, env_prefix:) }
 
+  let(:env_prefix) { "" }
   let(:supplied_name) { "foo" }
   let(:base_data) { {description:, type:, enabled:, default:, multi:, env:, long:, short:} }
   let(:data) { base_data }
@@ -75,6 +76,11 @@ RSpec.describe Unfig::ParamConfig do
       let(:data) { base_data.except(:env) }
       it { is_expected.to eq("FOO") }
 
+      context "and there is an env_prefix supplied" do
+        let(:env_prefix) { "MYGEM_" }
+        it { is_expected.to eq("MYGEM_FOO") }
+      end
+
       context "and name includes underscores" do
         let(:supplied_name) { "foo_bar" }
         it { is_expected.to eq("FOO_BAR") }
@@ -84,6 +90,11 @@ RSpec.describe Unfig::ParamConfig do
     context "when supplied as a string" do
       let(:env) { "FOO2" }
       it { is_expected.to eq("FOO2") }
+
+      context "and there is an env_prefix supplied" do
+        let(:env_prefix) { "MYGEM_" }
+        it { is_expected.to eq("MYGEM_FOO2") }
+      end
     end
   end
 end

--- a/spec/unfig/param_config_spec.rb
+++ b/spec/unfig/param_config_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Unfig::ParamConfig do
 
       context "and there is an env_prefix supplied" do
         let(:env_prefix) { "MYGEM_" }
-        it { is_expected.to eq("MYGEM_FOO2") }
+        it { is_expected.to eq("FOO2") }
       end
     end
   end

--- a/spec/unfig/params_config_spec.rb
+++ b/spec/unfig/params_config_spec.rb
@@ -42,6 +42,45 @@ RSpec.describe Unfig::ParamsConfig do
       let(:data) { {banner: "This banner", params: {foo: foo_config, bar: bar_config, baz: baz_config}} }
       it { is_expected.to eq("This banner") }
     end
+
+    context "when a non-string banner is supplied" do
+      let(:data) { {banner: :mybanner, params: {foo: foo_config, bar: bar_config, baz: baz_config}} }
+
+      it "raises Invalid" do
+        expect { banner }.to raise_error(Unfig::Invalid, /Non-string banner supplied/)
+      end
+    end
+  end
+
+  describe "#env_prefix" do
+    subject(:env_prefix) { config.env_prefix }
+
+    context "when no env_prefix is supplied" do
+      let(:data) { {params: {foo: foo_config, bar: bar_config, baz: baz_config}} }
+      it { is_expected.to eq("") }
+    end
+
+    context "when an env_prefix is supplied" do
+      let(:data) { {env_prefix: supplied_prefix, params: {foo: foo_config, bar: bar_config, baz: baz_config}} }
+      let(:supplied_prefix) { "FOO" }
+      it { is_expected.to eq("FOO") }
+
+      context "with some whitespace included" do
+        let(:supplied_prefix) { "FOO BAR" }
+
+        it "raises Invalid" do
+          expect { env_prefix }.to raise_error(Unfig::Invalid, /No whitespace is allowed/)
+        end
+      end
+
+      context "when a non-string env_prefix is supplied" do
+        let(:supplied_prefix) { 5 }
+
+        it "raises Invalid" do
+          expect { env_prefix }.to raise_error(Unfig::Invalid, /Non-string env_prefix/)
+        end
+      end
+    end
   end
 
   describe "#params" do

--- a/spec/unfig_spec.rb
+++ b/spec/unfig_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Unfig do
     end
 
     context "with several options passed in and an env set" do
-      let(:env) { {"COUNT" => "5"} }
+      let(:env) { {"TEST_COUNT" => "5"} }
 
       it "produces the expected output" do
         stdout, stderr, status = Open3.capture3(env, script_path, "--no-color", "--voltron=face", "-v", "--voltron=knee")


### PR DESCRIPTION
When the `env` is supplied, we want to use that. But often we don't want to bother, and it'd be convenient to be able to specify a prefix to use on all of the _inferred_ env names.

Add a `env_prefix` value that the ParamsConfig can take (defaults to ""). If supplied, all of the params that specify an `env` will be unchanged, but any that do not will have the prefix added to their inferred env name.

```ruby
Unfig.load_options(
  env_prefix: "MY_GEM_"
  values: {
    foo: {description: "foo?", type: "boolean", default: false},
    bar: {description: "bar?", type: "string", default: "yeah"},
    baz: {description: "baz?", type: "string", default: "bazbaz", env: "MY_BAZ"}
  }
```

Fixes #2 